### PR TITLE
Update email_router.py

### DIFF
--- a/routers/email_router.py
+++ b/routers/email_router.py
@@ -117,6 +117,35 @@ async def handle_input(message: Message):
             else:
                 state["files"].append((message.document.file_name, file_bytes))
                 await message.answer(f"📎 Файл «{message.document.file_name}» прикреплён.")
+        elif message.photo:
+            # Берем фото с наивысшим качеством (последнее в массиве)
+            photo = message.photo[-1]
+            file = await message.bot.download(photo)
+            file_bytes = file.read()
+            file_name = f"screenshot_{photo.file_unique_id}.jpg"
+            
+            if message.caption:
+                lines = message.caption.strip().splitlines()
+                if len(lines) >= 2:
+                    subject = lines[0]
+                    body = "\n".join(lines[1:])
+                    recipient = state["recipient"] or default_recipient
+                    attachments = [(file_name, file_bytes)]
+                    success = send_email_oauth2(recipient, subject, body, attachments)
+                    if success:
+                        await message.answer("✅ Письмо с изображением отправлено.")
+                    else:
+                        await message.answer(MESSAGES["email_failed"])
+                    state["draft"] = {}
+                    state["files"] = []
+                    user_states[user_id] = state
+                    return
+                else:
+                    await message.answer(MESSAGES["invalid_format"])
+                    return
+            else:
+                state["files"].append((file_name, file_bytes))
+                await message.answer(f"📎 Изображение «{file_name}» прикреплено.")
         elif not state["draft"] and message.text:
             lines = text.splitlines()
             if len(lines) >= 2:


### PR DESCRIPTION
# 🐛 Исправление бага с отправкой сжатых изображений

## Проблема
При попытке отправить скриншот с включенной галочкой "сжать изображение" бот выдавал ошибку:


## ✅ Что исправлено

### 🔧 Техническое решение
- **Добавлен блок `elif message.photo:`** для корректной обработки сжатых изображений
- **Автоматический выбор наивысшего качества** из массива фотографий (`message.photo[-1]`)
- **Генерация уникальных имен файлов** в формате `screenshot_{file_unique_id}.jpg`
- **Единообразная обработка** сжатых изображений аналогично документам

### 📋 Новая логика работы
| Тип контента | Обработка | Описание |
|-------------|-----------|----------|
| **Несжатые файлы/изображения** | `if message.document:` | Оригинальное имя файла сохраняется |
| **Сжатые изображения (скриншоты)** | `elif message.photo:` | Автогенерация имени `screenshot_*.jpg` |
| **Текстовые сообщения** | `elif message.text:` | Обработка темы и содержания письма |

### 🎯 Функциональность
**С подписью (тема + текст):**
- ✉️ Мгновенная отправка письма с прикрепленным изображением
- ✅ Уведомление: *"Письмо с изображением отправлено"*

**Без подписи:**
- 📎 Добавление в черновик для последующей отправки
- ✅ Уведомление: *"Изображение «screenshot_xxx.jpg» прикреплено"*

## 🎉 Результат
- ❌ **Больше никаких ошибок** при отправке сжатых скриншотов
- ✅ **Полная поддержка** всех типов изображений (сжатые и несжатые)
- 🔄 **Унифицированный workflow** для работы с медиафайлами